### PR TITLE
Fix API compatibility for modern BetterDiscord versions

### DIFF
--- a/src/NitroStreams.jsx
+++ b/src/NitroStreams.jsx
@@ -10,10 +10,10 @@
 module.exports = class NitroStreams {
   uiInjectInterval = null;
   nitroInterval = null;
-  getCurrentUser = BdApi.findModuleByProps("getCurrentUser").getCurrentUser;
+  getCurrentUser = BdApi.Webpack.getStore("UserStore").getCurrentUser;
 
   showInfo() {
-    BdApi.alert(
+    BdApi.UI.alert(
       "NitroStreams",
       <div
         style={{
@@ -49,9 +49,9 @@ module.exports = class NitroStreams {
   }
 
   load() {
-    if (BdApi.loadData("NitroStreams", "loaded") !== true) {
+    if (BdApi.Data.load("NitroStreams", "loaded") !== true) {
       this.showInfo();
-      BdApi.saveData("NitroStreams", "loaded", true);
+      BdApi.Data.save("NitroStreams", "loaded", true);
     }
   }
 


### PR DESCRIPTION
Replace deprecated BdApi.findModuleByProps with BdApi.Webpack.getStore
Replace BdApi.loadData/saveData with BdApi.Data.load/save
Replace BdApi.alert with BdApi.UI.alert

This fixes TypeError issues when loading the plugin in current BetterDiscord versions.